### PR TITLE
fix: fixing zp panics when file doesn't exist Issue #1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use arboard::Clipboard;
 use std::error::Error;
 use std::fs;
+use std::path::Path;
 use std::process;
 
 #[derive(Debug)]
@@ -9,17 +10,29 @@ pub struct Query {
 }
 
 impl Query {
-    pub fn build(
-        mut args: impl Iterator<Item = String>,
-    ) -> Result<Query, &'static str> {
+    pub fn build(mut args: impl Iterator<Item = String>) -> Result<Query, &'static str> {
         args.next();
-        
+
         let source = match args.next() {
             Some(arg) => arg,
             None => return Err("No source to copy from"),
         };
 
+        if let Err(error) = Query::check_file_path(&source) {
+            return Err(error);
+        }
+
         Ok(Query { source })
+    }
+
+    pub fn check_file_path(file_path: &str) -> Result<(), &'static str> {
+        if Path::new(file_path).is_dir() {
+            return Err("Received path instead of a file location");
+        }
+        if !Path::new(file_path).is_file() {
+            return Err("File does not exist");
+        }
+        Ok(())
     }
 }
 
@@ -39,7 +52,6 @@ pub fn cpy<'a>(contents: &'a str) {
         eprintln!("Couldn't copy to clipboard: {}", err);
         process::exit(1);
     });
-
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Resolves Issue #1 i.e when the file doesn't exist then it returns a valid error to the user.